### PR TITLE
feat: add assignee support with assign/remove picker and assigned-to-…

### DIFF
--- a/src/main/api-client.ts
+++ b/src/main/api-client.ts
@@ -476,6 +476,50 @@ export function updateTaskPosition(
   })
 }
 
+// --- Current user ---
+
+export function fetchUser(): Promise<ApiResult<unknown>> {
+  const c = getConfigOrFail()
+  if ('success' in c) return Promise.resolve(c)
+
+  return requestWithRetry<unknown>('GET', `${c.url}/api/v1/user`, c.token)
+}
+
+// --- Assignees ---
+
+export function searchUsers(query: string): Promise<ApiResult<unknown[]>> {
+  const c = getConfigOrFail()
+  if ('success' in c) return Promise.resolve(c)
+
+  const qs = new URLSearchParams()
+  if (query) qs.set('s', query)
+  const url = qs.toString() ? `${c.url}/api/v1/users?${qs}` : `${c.url}/api/v1/users`
+  return requestWithRetry<unknown[]>('GET', url, c.token)
+}
+
+export function addAssigneeToTask(taskId: number, userId: number): Promise<ApiResult<unknown>> {
+  const c = getConfigOrFail()
+  if ('success' in c) return Promise.resolve(c)
+
+  return requestWithRetry<unknown>(
+    'PUT',
+    `${c.url}/api/v1/tasks/${taskId}/assignees`,
+    c.token,
+    { user_id: userId }
+  )
+}
+
+export function removeAssigneeFromTask(taskId: number, userId: number): Promise<ApiResult<void>> {
+  const c = getConfigOrFail()
+  if ('success' in c) return Promise.resolve(c)
+
+  return requestWithRetry<void>(
+    'DELETE',
+    `${c.url}/api/v1/tasks/${taskId}/assignees/${userId}`,
+    c.token
+  )
+}
+
 // --- Connection Test (takes explicit url/token, not from config) ---
 
 export function testConnection(

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -27,10 +27,13 @@ import {
   uploadTaskAttachment,
   deleteTaskAttachment,
   downloadTaskAttachment,
+  searchUsers,
+  addAssigneeToTask,
+  removeAssigneeFromTask,
+  fetchUser,
 } from './api-client'
 import { loadConfig, saveConfig, type AppConfig } from './config'
 import { discoverProviders, discoverAuthMethods } from './auth/oidc-discovery'
-import { fetchCurrentUser } from './auth/user-info'
 import { authManager } from './auth/auth-manager'
 import { buildViewerFilterParams } from './quick-entry/filter-builder'
 import {
@@ -204,13 +207,9 @@ export function registerIpcHandlers(): void {
   })
 
   ipcMain.handle('auth:get-user', async () => {
-    const config = loadConfig()
-    if (!config?.vikunja_url) return null
-    const token = config.auth_method === 'api_token'
-      ? (getAPIToken() || config.api_token)
-      : authManager.getTokenSync()
-    if (!token) return null
-    return fetchCurrentUser(config.vikunja_url, token)
+    const result = await fetchUser()
+    if (!result.success) return null
+    return result.data
   })
 
   ipcMain.handle('auth:check', () => {
@@ -558,6 +557,19 @@ export function registerIpcHandlers(): void {
     } catch (err: unknown) {
       return { success: false, error: err instanceof Error ? err.message : 'Failed to open file' }
     }
+  })
+
+  // --- Assignees IPC ---
+  ipcMain.handle('search-users', (_event, query: string) => {
+    return searchUsers(query)
+  })
+
+  ipcMain.handle('add-assignee-to-task', (_event, taskId: number, userId: number) => {
+    return addAssigneeToTask(taskId, userId)
+  })
+
+  ipcMain.handle('remove-assignee-from-task', (_event, taskId: number, userId: number) => {
+    return removeAssigneeFromTask(taskId, userId)
   })
 
   ipcMain.handle('pick-and-upload-attachment', async (_event, taskId: number) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -97,6 +97,14 @@ const api = {
   pickAndUploadAttachment: (taskId: number) =>
     ipcRenderer.invoke('pick-and-upload-attachment', taskId),
 
+  // Assignees
+  searchUsers: (query: string) =>
+    ipcRenderer.invoke('search-users', query),
+  addAssigneeToTask: (taskId: number, userId: number) =>
+    ipcRenderer.invoke('add-assignee-to-task', taskId, userId),
+  removeAssigneeFromTask: (taskId: number, userId: number) =>
+    ipcRenderer.invoke('remove-assignee-from-task', taskId, userId),
+
   // Obsidian
   openDeepLink: (url: string) => ipcRenderer.invoke('open-deep-link', url),
   testObsidianConnection: () => ipcRenderer.invoke('test-obsidian-connection'),

--- a/src/renderer/components/task-list/AssigneePickerPopover.tsx
+++ b/src/renderer/components/task-list/AssigneePickerPopover.tsx
@@ -1,0 +1,104 @@
+import { useRef, useEffect, useState } from 'react'
+import { Check } from 'lucide-react'
+import { useAddAssignee, useRemoveAssignee } from '@/hooks/use-task-mutations'
+import { api } from '@/lib/api'
+import type { VikunjaUser } from '@/lib/vikunja-types'
+
+interface AssigneePickerPopoverProps {
+  taskId: number
+  currentAssignees: VikunjaUser[]
+  onClose: () => void
+}
+
+export function AssigneePickerPopover({ taskId, currentAssignees, onClose }: AssigneePickerPopoverProps) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [searchResults, setSearchResults] = useState<VikunjaUser[]>([])
+  const addAssignee = useAddAssignee()
+  const removeAssignee = useRemoveAssignee()
+
+  const currentIds = new Set(currentAssignees.map((u) => u.id))
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose()
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [onClose])
+
+  // Load users on mount and on search query change (debounced)
+  useEffect(() => {
+    const timer = setTimeout(async () => {
+      const result = await api.searchUsers(searchQuery)
+      if (result.success && Array.isArray(result.data)) setSearchResults(result.data as VikunjaUser[])
+    }, 150)
+    return () => clearTimeout(timer)
+  }, [searchQuery])
+
+  const toggle = (user: VikunjaUser) => {
+    if (currentIds.has(user.id)) {
+      removeAssignee.mutate({ taskId, userId: user.id })
+    } else {
+      addAssignee.mutate({ taskId, userId: user.id })
+    }
+  }
+
+  // Merge current assignees with search results (current always shown, no dupes)
+  const merged: VikunjaUser[] = [...currentAssignees]
+  for (const u of searchResults) {
+    if (!currentIds.has(u.id)) merged.push(u)
+  }
+
+  return (
+    <div
+      ref={ref}
+      className="absolute right-0 top-full z-50 mt-1 w-52 rounded-lg border border-[var(--border-color)] bg-[var(--bg-primary)] shadow-lg"
+    >
+      <div className="border-b border-[var(--border-color)] px-3 py-2">
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="Search members..."
+          autoFocus
+          className="w-full bg-transparent text-xs text-[var(--text-primary)] placeholder:text-[var(--text-secondary)] focus:outline-none"
+        />
+      </div>
+
+      <div className="max-h-60 overflow-y-auto py-1">
+        {merged.length === 0 && (
+          <div className="px-3 py-2 text-xs text-[var(--text-secondary)]">No members found</div>
+        )}
+
+        {merged.map((user) => {
+          const display = user.name?.trim() || user.username
+          const initials = display
+            .split(' ')
+            .map((w) => w[0])
+            .slice(0, 2)
+            .join('')
+            .toUpperCase()
+          const isAssigned = currentIds.has(user.id)
+
+          return (
+            <button
+              key={user.id}
+              type="button"
+              onClick={() => toggle(user)}
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-[var(--text-primary)] hover:bg-[var(--bg-hover)]"
+            >
+              <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-[var(--accent-blue)]/20 text-[9px] font-semibold text-[var(--accent-blue)]">
+                {initials}
+              </span>
+              <span className="min-w-0 flex-1 truncate">{display}</span>
+              {isAssigned && (
+                <Check className="h-3.5 w-3.5 shrink-0 text-[var(--accent-blue)]" />
+              )}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/task-list/TaskList.tsx
+++ b/src/renderer/components/task-list/TaskList.tsx
@@ -1,8 +1,9 @@
 import { useState, useRef, useEffect, useCallback, useMemo, Fragment } from 'react'
-import { Plus, Inbox } from 'lucide-react'
+import { Plus, Inbox, UserCheck } from 'lucide-react'
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { cn } from '@/lib/cn'
 import { useCreateTask, useCompleteTask, useUpdateTask, useDeleteTask, useAddLabel } from '@/hooks/use-task-mutations'
+import { useCurrentUser } from '@/hooks/use-current-user'
 import { useSelectionStore } from '@/stores/selection-store'
 import { useTaskParser } from '@/hooks/use-task-parser'
 import { useLabels } from '@/hooks/use-labels'
@@ -49,6 +50,8 @@ export function TaskList({
 }: TaskListProps) {
   const [isAdding, setIsAdding] = useState(false)
   const [showNotes, setShowNotes] = useState(false)
+  const [filterMyTasks, setFilterMyTasks] = useState(false)
+  const { data: currentUser, isLoading: userLoading } = useCurrentUser()
   const [defaultDateDismissed, setDefaultDateDismissed] = useState(false)
   const [newDescription, setNewDescription] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
@@ -236,6 +239,11 @@ export function TaskList({
     [collapseAll, setFocusedTask]
   )
 
+  const visibleTasks = useMemo(() => {
+    if (!filterMyTasks || !currentUser) return tasks
+    return tasks.filter((t) => t.assignees?.some((a) => a.id === currentUser.id))
+  }, [tasks, filterMyTasks, currentUser])
+
   // Keyboard navigation
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
@@ -244,7 +252,7 @@ export function TaskList({
       const tag = active?.tagName.toLowerCase()
       if (tag === 'input' || tag === 'textarea' || tag === 'select') return
 
-      const taskCount = tasks.length
+      const taskCount = visibleTasks.length
 
       // Ctrl+N / ⌘N: New task
       if ((e.ctrlKey || e.metaKey) && e.key === 'n') {
@@ -271,7 +279,7 @@ export function TaskList({
       if (taskCount === 0) return
 
       const currentIndex = focusedTaskId
-        ? tasks.findIndex((t) => t.id === focusedTaskId)
+        ? visibleTasks.findIndex((t) => t.id === focusedTaskId)
         : -1
 
       // Arrow Up
@@ -279,7 +287,7 @@ export function TaskList({
         e.preventDefault()
         if (expandedTaskId) return // don't navigate while editing
         const newIndex = currentIndex <= 0 ? 0 : currentIndex - 1
-        setFocusedTask(tasks[newIndex].id)
+        setFocusedTask(visibleTasks[newIndex].id)
         return
       }
 
@@ -288,7 +296,7 @@ export function TaskList({
         e.preventDefault()
         if (expandedTaskId) return // don't navigate while editing
         const newIndex = currentIndex >= taskCount - 1 ? taskCount - 1 : currentIndex + 1
-        setFocusedTask(tasks[newIndex].id)
+        setFocusedTask(visibleTasks[newIndex].id)
         return
       }
 
@@ -317,16 +325,16 @@ export function TaskList({
         e.preventDefault()
         const targetId = expandedTaskId || focusedTaskId
         if (!targetId) return
-        const task = tasks.find((t) => t.id === targetId)
+        const task = visibleTasks.find((t) => t.id === targetId)
         if (task && !task.done) {
           completeTask.mutate(task)
           collapseAll()
           // Move focus to next task
-          const idx = tasks.findIndex((t) => t.id === targetId)
+          const idx = visibleTasks.findIndex((t) => t.id === targetId)
           if (idx < taskCount - 1) {
-            setFocusedTask(tasks[idx + 1].id)
+            setFocusedTask(visibleTasks[idx + 1].id)
           } else if (idx > 0) {
-            setFocusedTask(tasks[idx - 1].id)
+            setFocusedTask(visibleTasks[idx - 1].id)
           } else {
             setFocusedTask(null)
           }
@@ -339,13 +347,13 @@ export function TaskList({
         e.preventDefault()
         const targetId = expandedTaskId || focusedTaskId
         if (!targetId) return
-        const idx = tasks.findIndex((t) => t.id === targetId)
+        const idx = visibleTasks.findIndex((t) => t.id === targetId)
         deleteTask.mutate(targetId)
         collapseAll()
         if (idx < taskCount - 1) {
-          setFocusedTask(tasks[idx + 1].id)
+          setFocusedTask(visibleTasks[idx + 1].id)
         } else if (idx > 0) {
-          setFocusedTask(tasks[idx - 1].id)
+          setFocusedTask(visibleTasks[idx - 1].id)
         } else {
           setFocusedTask(null)
         }
@@ -357,7 +365,7 @@ export function TaskList({
         e.preventDefault()
         const targetId = expandedTaskId || focusedTaskId
         if (!targetId) return
-        const task = tasks.find((t) => t.id === targetId)
+        const task = visibleTasks.find((t) => t.id === targetId)
         if (task) {
           const today = new Date()
           today.setHours(0, 0, 0, 0)
@@ -376,7 +384,7 @@ export function TaskList({
       }
     },
     [
-      tasks,
+      visibleTasks,
       focusedTaskId,
       expandedTaskId,
       projectId,
@@ -477,16 +485,32 @@ export function TaskList({
         onClick={handleHeaderClick}
       >
         <h1 className="text-xl font-bold text-[var(--text-primary)]">{title}</h1>
-        {showNewTask && projectId && (
+        <div className="flex items-center gap-1">
           <button
             type="button"
-            onClick={() => setIsAdding(true)}
-            className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--accent-blue)]"
-            aria-label="New task"
+            onClick={() => setFilterMyTasks((v) => !v)}
+            className={cn(
+              'flex h-7 w-7 items-center justify-center rounded-md transition-colors',
+              filterMyTasks
+                ? 'bg-[var(--accent-blue)]/10 text-[var(--accent-blue)]'
+                : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--accent-blue)]'
+            )}
+            aria-label="Filter: assigned to me"
+            title="Assigned to me"
           >
-            <Plus className="h-4 w-4" />
+            <UserCheck className="h-4 w-4" />
           </button>
-        )}
+          {showNewTask && projectId && (
+            <button
+              type="button"
+              onClick={() => setIsAdding(true)}
+              className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--accent-blue)]"
+              aria-label="New task"
+            >
+              <Plus className="h-4 w-4" />
+            </button>
+          )}
+        </div>
       </div>
 
       <div
@@ -498,14 +522,20 @@ export function TaskList({
 
         {isAdding && taskInputElement}
 
-        {tasks.length === 0 && !isAdding && !children ? (
-          <EmptyState icon={Inbox} title={emptyTitle} subtitle={emptySubtitle} />
+        {visibleTasks.length === 0 && !isAdding && !children ? (
+          filterMyTasks ? (
+            userLoading
+              ? <EmptyState icon={UserCheck} title="Loading user info…" subtitle="Identifying your account" />
+              : <EmptyState icon={UserCheck} title="No tasks assigned to you" subtitle="Assign yourself to a task using the person icon in any task row" />
+          ) : (
+            <EmptyState icon={Inbox} title={emptyTitle} subtitle={emptySubtitle} />
+          )
         ) : sortable ? (
           <SortableContext
-            items={tasks.map((t) => `task-${t.id}`)}
+            items={visibleTasks.map((t) => `task-${t.id}`)}
             strategy={verticalListSortingStrategy}
           >
-            {tasks.map((task, i) => (
+            {visibleTasks.map((task, i) => (
               <Fragment key={task.id}>
                 {insertIndex === i && (
                   <div className="mx-4 flex items-center gap-1 py-0.5">
@@ -516,7 +546,7 @@ export function TaskList({
                 <TaskRow task={task} sortable />
               </Fragment>
             ))}
-            {insertIndex != null && insertIndex >= tasks.length && (
+            {insertIndex != null && insertIndex >= visibleTasks.length && (
               <div className="mx-4 flex items-center gap-1 py-0.5">
                 <div className="h-1.5 w-1.5 rounded-full bg-[var(--accent-blue)]" />
                 <div className="h-[2px] flex-1 rounded-full bg-[var(--accent-blue)]" />
@@ -524,7 +554,7 @@ export function TaskList({
             )}
           </SortableContext>
         ) : (
-          tasks.map((task) => <TaskRow key={task.id} task={task} />)
+          visibleTasks.map((task) => <TaskRow key={task.id} task={task} />)
         )}
 
         {children}

--- a/src/renderer/components/task-list/TaskRow.tsx
+++ b/src/renderer/components/task-list/TaskRow.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
-import { Calendar, Tag, ListChecks, FolderOpen, Trash2, Bell, Repeat, Paperclip } from 'lucide-react'
+import { Calendar, Tag, ListChecks, FolderOpen, Trash2, Bell, Repeat, Paperclip, UserPlus } from 'lucide-react'
 import { useDraggable } from '@dnd-kit/core'
 import { useSortable, defaultAnimateLayoutChanges } from '@dnd-kit/sortable'
 import type { AnimateLayoutChanges } from '@dnd-kit/sortable'
@@ -18,11 +18,12 @@ import { SubtaskList } from './SubtaskList'
 import { ProjectPickerPopover } from './ProjectPickerPopover'
 import { ReminderPickerPopover } from './ReminderPickerPopover'
 import { AttachmentPickerPopover } from './AttachmentPickerPopover'
+import { AssigneePickerPopover } from './AssigneePickerPopover'
 import { TaskLinkIcon } from '@/components/TaskLinkIcon'
 import { stripNoteLink, stripPageLink, extractNoteLinkHtml, extractPageLinkHtml } from '@/lib/note-link'
 import { formatRecurrenceLabel } from '@/lib/recurrence'
 
-type PopoverType = 'date' | 'label' | 'project' | 'subtasks' | 'reminder' | 'attachment' | null
+type PopoverType = 'date' | 'label' | 'project' | 'subtasks' | 'reminder' | 'attachment' | 'assignee' | null
 
 function getLabelStyle(hex: string | undefined): React.CSSProperties {
   if (!hex) return { backgroundColor: 'var(--bg-hover)', color: 'var(--text-secondary)' }
@@ -315,6 +316,29 @@ export function TaskRow({ task, sortable = false }: TaskRowProps) {
           </div>
         )}
 
+        {(task.assignees?.length ?? 0) > 0 && (
+          <div className="flex shrink-0 items-center gap-1">
+            {task.assignees!.map((u) => {
+              const display = u.name?.trim() || u.username
+              const initials = display
+                .split(' ')
+                .map((w) => w[0])
+                .slice(0, 2)
+                .join('')
+                .toUpperCase()
+              return (
+                <span
+                  key={u.id}
+                  title={display}
+                  className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-[var(--accent-blue)]/20 text-[9px] font-semibold text-[var(--accent-blue)]"
+                >
+                  {initials}
+                </span>
+              )
+            })}
+          </div>
+        )}
+
         <span
           className={cn(
             'min-w-0 flex-1 truncate text-[13px] text-[var(--text-primary)]',
@@ -535,6 +559,19 @@ export function TaskRow({ task, sortable = false }: TaskRowProps) {
           </button>
           <button
             type="button"
+            onClick={() => togglePopover('assignee')}
+            className={cn(
+              'flex h-6 w-6 items-center justify-center rounded transition-colors',
+              activePopover === 'assignee' || (task.assignees?.length ?? 0) > 0
+                ? 'bg-[var(--accent-blue)]/10 text-[var(--accent-blue)]'
+                : 'text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]'
+            )}
+            title="Assign members"
+          >
+            <UserPlus className="h-3.5 w-3.5" />
+          </button>
+          <button
+            type="button"
             onClick={() => togglePopover('project')}
             className={cn(
               'flex h-6 w-6 items-center justify-center rounded transition-colors',
@@ -592,6 +629,13 @@ export function TaskRow({ task, sortable = false }: TaskRowProps) {
           {activePopover === 'attachment' && (
             <AttachmentPickerPopover
               taskId={task.id}
+              onClose={() => setActivePopover(null)}
+            />
+          )}
+          {activePopover === 'assignee' && (
+            <AssigneePickerPopover
+              taskId={task.id}
+              currentAssignees={task.assignees ?? []}
               onClose={() => setActivePopover(null)}
             />
           )}

--- a/src/renderer/hooks/use-current-user.ts
+++ b/src/renderer/hooks/use-current-user.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query'
+import { api } from '@/lib/api'
+
+export function useCurrentUser() {
+  return useQuery({
+    queryKey: ['current-user'],
+    queryFn: async () => {
+      const user = await api.getUser()
+      if (!user) throw new Error('User not available')
+      return user
+    },
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  })
+}

--- a/src/renderer/hooks/use-task-mutations.ts
+++ b/src/renderer/hooks/use-task-mutations.ts
@@ -544,6 +544,40 @@ export function useDeleteLabel() {
   })
 }
 
+// --- Assignees ---
+
+export function useAddAssignee() {
+  const qc = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ taskId, userId }: { taskId: number; userId: number }) => {
+      const result = await api.addAssigneeToTask(taskId, userId)
+      if (!result.success) throw new Error(result.error)
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ['tasks'] })
+      qc.invalidateQueries({ queryKey: ['view-tasks'] })
+      qc.invalidateQueries({ queryKey: ['section-tasks'] })
+    },
+  })
+}
+
+export function useRemoveAssignee() {
+  const qc = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ taskId, userId }: { taskId: number; userId: number }) => {
+      const result = await api.removeAssigneeFromTask(taskId, userId)
+      if (!result.success) throw new Error(result.error)
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ['tasks'] })
+      qc.invalidateQueries({ queryKey: ['view-tasks'] })
+      qc.invalidateQueries({ queryKey: ['section-tasks'] })
+    },
+  })
+}
+
 // --- Attachments ---
 
 export function useTaskAttachments(taskId: number, enabled: boolean) {

--- a/src/renderer/lib/api.ts
+++ b/src/renderer/lib/api.ts
@@ -156,6 +156,14 @@ export const api = {
   pickAndUploadAttachment: (taskId: number) =>
     window.api.pickAndUploadAttachment(taskId) as Promise<ApiResult<{ count: number }>>,
 
+  // Assignees
+  searchUsers: (query: string) =>
+    window.api.searchUsers(query) as Promise<ApiResult<VikunjaUser[]>>,
+  addAssigneeToTask: (taskId: number, userId: number) =>
+    window.api.addAssigneeToTask(taskId, userId) as Promise<ApiResult<VikunjaUser>>,
+  removeAssigneeFromTask: (taskId: number, userId: number) =>
+    window.api.removeAssigneeFromTask(taskId, userId) as Promise<ApiResult<void>>,
+
   // Window controls
   windowMinimize: () => window.api.windowMinimize(),
   windowMaximize: () => window.api.windowMaximize(),

--- a/src/renderer/lib/vikunja-types.ts
+++ b/src/renderer/lib/vikunja-types.ts
@@ -20,6 +20,13 @@ export interface TaskAttachment {
   file: TaskFile
 }
 
+export interface VikunjaUser {
+  id: number
+  username: string
+  name: string
+  email?: string
+}
+
 export interface Task {
   id: number
   title: string
@@ -32,6 +39,7 @@ export interface Task {
   priority: number // 0=unset, 1=low, 2=medium, 3=high, 4=urgent
   project_id: number
   labels: Label[] | null
+  assignees?: VikunjaUser[] | null
   reminders: TaskReminder[] | null
   attachments?: TaskAttachment[] | null
   related_tasks?: Record<string, Task[]> | null


### PR DESCRIPTION
…me filter

- Add VikunjaUser type and assignees field to Task in vikunja-types
- Show assignee avatars (initials) to the left of the task title in collapsed rows
- Add UserPlus button in expanded task row that opens AssigneePickerPopover
- AssigneePickerPopover: debounced user search, toggle assign/unassign per user
- Add searchUsers, addAssigneeToTask, removeAssigneeFromTask through the full IPC stack (api-client → ipc-handlers → preload → api.ts)
- Add useAddAssignee and useRemoveAssignee mutations with query invalidation
- Add fetchUser() in api-client using requestWithRetry (replaces net.fetch-based fetchCurrentUser for reliability)
- Add useCurrentUser hook (TanStack Query, 5min stale, throws on null for clean undefined data)
- Add UserCheck filter button in TaskList header (always visible when authenticated)
- Filter visibleTasks to only tasks assigned to the current user when active
- Show "No tasks assigned to you" empty state when filter is on and list is empty