### PR TITLE
feat: add Linux (AppImage) support

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -47,9 +47,15 @@ jobs:
       - name: Build app
         run: npm run build
 
+      # electron-builder.yml lists both x64 and arm64 under linux.target so
+      # local `npm run dist:linux` builds everything. In CI we restrict each
+      # matrix runner to a single arch using the positional `target:arch`
+      # syntax, which overrides the yml arch list. Plain `--${{ matrix.arch }}`
+      # is additive, not restrictive, so without this override each runner
+      # would duplicate the work by also building the other arch.
       - name: Package Linux (${{ matrix.arch }})
         timeout-minutes: 30
-        run: npx electron-builder --linux --${{ matrix.arch }} --publish never
+        run: npx electron-builder --linux AppImage:${{ matrix.arch }} --publish never
 
       - name: Upload AppImage artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,59 @@
+# Linux CI Build
+#
+# Builds and packages Vicu for Linux on every push to main, PRs targeting main,
+# and manual triggers. Produces AppImage artifacts for x64 and arm64 without
+# publishing to GitHub Releases. Use this to smoke-test the Linux build without
+# tagging a release.
+
+name: Build Linux
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: x64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Cache Electron
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/electron
+          key: electron-${{ matrix.arch }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            electron-${{ matrix.arch }}-
+
+      - run: npm ci
+
+      - name: Build app
+        run: npm run build
+
+      - name: Package Linux (${{ matrix.arch }})
+        timeout-minutes: 30
+        run: npx electron-builder --linux --${{ matrix.arch }} --publish never
+
+      - name: Upload AppImage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vicu-linux-${{ matrix.arch }}-appimage
+          path: dist/*.AppImage
+          if-no-files-found: warn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,3 +52,38 @@ jobs:
           done
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: x64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Build and publish (${{ matrix.arch }})
+        run: npm run dist:linux:publish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Remove blockmap assets
+        run: |
+          for asset in dist/*.blockmap; do
+            [ -f "$asset" ] || continue
+            name=$(basename "$asset")
+            gh release delete-asset "${{ github.ref_name }}" "$name" --yes || true
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,8 +73,13 @@ jobs:
 
       - run: npm ci
 
+      # electron-builder.yml lists both arches under linux.target; we override
+      # via the positional `AppImage:<arch>` target so each matrix runner only
+      # builds and publishes its matrix arch. Without this override both
+      # runners would build both arches AND publish them, leading to duplicate
+      # asset-upload conflicts on the second runner.
       - name: Build and publish (${{ matrix.arch }})
-        run: npm run dist:linux:publish
+        run: npm run build && npx electron-builder --linux AppImage:${{ matrix.arch }} --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,24 +4,32 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**Vicu** — a task management desktop app for Windows and macOS, powered by [Vikunja](https://vikunja.io/) as the backend. Built with Electron + React + TypeScript + Tailwind CSS.
+**Vicu** — a task management desktop app for Windows, macOS, and Linux (AppImage), powered by [Vikunja](https://vikunja.io/) as the backend. Built with Electron + React + TypeScript + Tailwind CSS.
 
 ## Commands
 
 ```bash
-npm install          # Install dependencies
-npm run dev          # Start dev mode (electron-vite dev, opens app with HMR + DevTools)
-npm run build        # Production build (electron-vite build)
-npm run start        # Preview production build (electron-vite preview)
-npm run dist         # Build + package Windows installer (electron-builder)
-npm run dist:publish # Build + package + upload to GitHub release (used by CI)
+npm install            # Install dependencies
+npm run dev            # Start dev mode (electron-vite dev, opens app with HMR + DevTools)
+npm run build          # Production build (electron-vite build)
+npm run start          # Preview production build (electron-vite preview)
+npm run dist           # Build + package Windows installer (electron-builder)
+npm run dist:publish   # Build + package + upload to GitHub release (used by CI)
+npm run dist:mac       # Build + package macOS DMG
+npm run dist:linux     # Build + package Linux AppImage (x64 + arm64 per builder config)
 ```
 
 No test runner or linter is configured.
 
 ## CI/CD
 
-GitHub Actions workflow at `.github/workflows/release.yml` triggers on tag pushes matching `v*`. It builds the Windows installer (`npm run dist:publish`) and uploads the artifact to the GitHub release automatically via `electron-builder --publish always`.
+GitHub Actions workflow at `.github/workflows/release.yml` triggers on tag pushes matching `v*`. It builds:
+
+- **Windows** NSIS x64 (`build-windows`, `windows-latest`, `npm run dist:publish`)
+- **macOS** DMG arm64 (`build-macos`, `macos-latest`, `npm run dist:mac:publish`)
+- **Linux** AppImage x64 + arm64 (`build-linux` matrix — `ubuntu-latest` for x64, `ubuntu-24.04-arm` for arm64, `npm run dist:linux:publish`)
+
+All three publish to the same GitHub draft release via `electron-builder --publish always`.
 
 **Do NOT manually create releases or attach build artifacts** — CI handles everything. `electron-builder --publish always` creates its own **draft** release, uploads the installer, then publishes it. If you manually create a release first via `gh release create`, electron-builder will create a separate draft and the manual release will have no assets.
 
@@ -105,11 +113,17 @@ Two auth methods supported:
 ### Platform Notes
 
 - **Platform constants**: `src/main/platform.ts` exports `isMac`, `isWindows`, `isLinux` — use these for all platform branching (not raw `process.platform` checks)
-- **Native integrations**: koffi FFI is Windows-only; macOS uses osascript-based alternatives in `obsidian-client.ts` and `window-url-reader.ts`
-- **Main window chrome**: `titleBarStyle: 'hiddenInset'` on macOS (native traffic lights), `frame: false` on Windows (custom WindowControls)
+- **Native integrations**: koffi FFI is Windows-only; macOS uses osascript-based alternatives in `obsidian-client.ts` and `window-url-reader.ts`; Linux has no equivalent and those features degrade gracefully
+- **Main window chrome**: `titleBarStyle: 'hiddenInset'` on macOS (native traffic lights); `frame: false` on Windows and Linux (custom WindowControls)
 - **Quick Entry/View popups**: on macOS, use `alwaysOnTop: true` (not `type: 'panel'` — panels auto-hide on app deactivation)
 - **macOS icon assets**: `resources/icon.icns` (app bundle), `resources/iconTemplate.png` + `@2x.png` (menu bar tray — "Template" suffix is case-sensitive for auto-inversion)
-- **Forge config**: `forge.config.ts` at project root, referenced from package.json `config.forge`
+- **Linux (AppImage)**:
+  - Target defined in `electron-builder.yml` `linux:` section — AppImage, x64 + arm64. Uses `build/icon.png` (512×512). `desktop.StartupWMClass: Vicu` is load-bearing on GNOME/Wayland so the app groups under its own dock icon instead of generic "Electron".
+  - Tray icon reuses `resources/icon.png` resized to 16×16 via the existing Windows fallback in `tray.ts`.
+  - Global shortcuts: Electron's `globalShortcut.register()` is unreliable on Wayland. `registerQuickEntryShortcuts` in `src/main/index.ts` already reports `{entry, viewer}` booleans; the latest state is surfaced via the `get-global-shortcut-status` IPC and rendered as a warning banner in Settings → Quick Entry / View with Linux-specific copy.
+  - Browser link mode: native-messaging host manifests are written to `~/.config/google-chrome|chromium|microsoft-edge|BraveSoftware/Brave-Browser|vivaldi/NativeMessagingHosts/` and `~/.mozilla/native-messaging-hosts/` (`browser-host-registration.ts`). The shell wrapper `vicu-bridge.sh` is generated in `app.getPath('userData')`, reusing the macOS `ensureShellWrapper()` code. PowerShell / AppleScript URL-from-window-title fallback does not run on Linux (Wayland blocks foreground introspection).
+  - Obsidian integration is stubbed out on Linux — `getForegroundProcessName()` returns `''` and `getObsidianContext()` silently returns `null`. The setting remains visible but no foreground-app detection runs.
+- **Forge config**: stale reference — Vicu uses electron-vite + electron-builder, not electron-forge. No `forge.config.ts` exists.
 
 ### Vikunja API docs
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A personal task manager for your desktop, powered by [Vikunja](https://vikunja.io/).
 
 ![License](https://img.shields.io/badge/license-MIT-blue)
-![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS-lightgrey)
+![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey)
 ![Built with](https://img.shields.io/badge/electron%20+%20react%20+%20typescript-47848F)
 
 <p align="center">
@@ -92,6 +92,7 @@ The [official Vikunja frontend](https://vikunja.io/) is a full project managemen
 |----------|--------|
 | Windows  | `.exe` (NSIS installer) |
 | macOS    | `.dmg` (Apple Silicon) |
+| Linux    | `.AppImage` (x64, arm64) |
 
 Grab the latest installer from [GitHub Releases](https://github.com/rendyhd/Vicu/releases).
 
@@ -108,6 +109,22 @@ xattr -cr /Applications/Vicu.app
 ```
 
 Either method is a one-time step. The app opens normally after that.
+
+### Linux — AppImage notes
+
+Make the AppImage executable before running it:
+
+```bash
+chmod +x Vicu-*.AppImage
+./Vicu-*.AppImage
+```
+
+A few platform caveats:
+
+- **Global hotkeys on Wayland**: Electron cannot register global shortcuts on Wayland without portal support. If Vicu shows a warning in Settings that it couldn't register the Quick Entry / Quick View hotkey, bind the keys via your desktop environment's keyboard settings instead, or trigger them from the tray icon. On X11 sessions, the hotkeys work as on Windows/macOS.
+- **System tray**: works out of the box on KDE, XFCE, Cinnamon, and most Wayland compositors. On GNOME you'll need the **AppIndicator and KStatusNotifierItem Support** extension.
+- **Browser link mode**: supported via the bundled Chrome/Firefox extension + native messaging. Enable it in Settings and click "Register browser hosts" — the manifests are written to `~/.config/<browser>/NativeMessagingHosts/` and `~/.mozilla/native-messaging-hosts/`. The Windows/macOS URL-from-window-title fallback is not available on Linux.
+- **Obsidian integration**: Windows and macOS only. On Linux the setting is visible but no foreground-app detection runs.
 
 ### Setup
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -57,6 +57,26 @@ mac:
   extendInfo:
     NSAppleEventsUsageDescription: "Vicu needs automation access to detect the active browser tab for quick task entry."
 
+linux:
+  icon: build/icon.png
+  category: Utility
+  synopsis: Task management app powered by Vikunja
+  description: A personal task manager for your desktop, powered by Vikunja. Frictionless capture, keyboard-driven review, and deep integration with your browser.
+  maintainer: rendyhd
+  target:
+    - target: AppImage
+      arch:
+        - x64
+        - arm64
+  desktop:
+    entry:
+      StartupWMClass: Vicu
+      Comment: Task management app powered by Vikunja
+      Keywords: task;todo;productivity;vikunja;
+
+appImage:
+  artifactName: "${productName}-${version}-${arch}.${ext}"
+
 dmg:
   sign: false
   writeUpdateInfo: false

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "dist:publish": "electron-vite build && electron-builder --win --publish always",
     "dist:mac": "electron-vite build && electron-builder --mac",
     "dist:mac:publish": "electron-vite build && electron-builder --mac --publish always",
+    "dist:linux": "electron-vite build && electron-builder --linux",
+    "dist:linux:publish": "electron-vite build && electron-builder --linux --publish always",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/src/main/auth/token-store.ts
+++ b/src/main/auth/token-store.ts
@@ -3,8 +3,13 @@ import { app, safeStorage } from 'electron'
 /** Expiry far in the future for user-provided API tokens with no inherent expiry */
 export const API_TOKEN_NO_EXPIRY = 4102444800 // 2100-01-01T00:00:00Z
 
+// Returns true if the token store can persist a value — either via real
+// safeStorage encryption or via the plaintext fallback. Callers that gate on
+// "should we save tokens at all?" want this to always be true; callers that
+// want to know specifically whether on-disk encryption is in effect should
+// call safeStorage.isEncryptionAvailable() directly.
 export function isEncryptionAvailable(): boolean {
-  return safeStorage.isEncryptionAvailable()
+  return true
 }
 import { readFileSync, writeFileSync, existsSync, unlinkSync, mkdirSync } from 'fs'
 import { join, dirname } from 'path'
@@ -46,12 +51,34 @@ function writeStore(data: AuthStore): void {
   writeFileSync(authPath, JSON.stringify(data, null, 2), 'utf-8')
 }
 
+// Tokens stored while safeStorage is unavailable get a "plain:" prefix so the
+// reader can tell them apart from base64-encoded ciphertext. Without this, a
+// keyring appearing after the first launch would leave the reader trying to
+// decrypt raw plaintext as base64 and permanently wedge auth until the user
+// logged in again. On Linux without a usable keyring, the fallback stores
+// tokens in cleartext under ~/.config/vicu/auth.json — the same effective
+// posture as every other Electron app in this situation (VS Code, Slack,
+// Signal, etc. all degrade to basic obfuscation when no keyring is available).
+const PLAIN_PREFIX = 'plain:'
+
 function encrypt(value: string): string {
-  const buffer = safeStorage.encryptString(value)
-  return buffer.toString('base64')
+  try {
+    if (!safeStorage.isEncryptionAvailable()) {
+      return PLAIN_PREFIX + value
+    }
+    const buffer = safeStorage.encryptString(value)
+    return buffer.toString('base64')
+  } catch (err) {
+    console.warn('[Auth] safeStorage.encryptString failed, falling back to plaintext:',
+      err instanceof Error ? err.message : err)
+    return PLAIN_PREFIX + value
+  }
 }
 
 function decrypt(encoded: string): string | null {
+  if (encoded.startsWith(PLAIN_PREFIX)) {
+    return encoded.slice(PLAIN_PREFIX.length)
+  }
   try {
     const buffer = Buffer.from(encoded, 'base64')
     return safeStorage.decryptString(buffer)

--- a/src/main/browser-host-registration.ts
+++ b/src/main/browser-host-registration.ts
@@ -3,7 +3,7 @@ import { execSync } from 'child_process'
 import { existsSync, writeFileSync, unlinkSync, mkdirSync } from 'fs'
 import { join, dirname } from 'path'
 import { homedir } from 'os'
-import { isMac, isWindows } from './platform'
+import { isMac, isWindows, isLinux } from './platform'
 
 const HOST_NAME = 'com.vicu.browser'
 // The existing signed Firefox extension (on AMO) from vikunja-quick-entry
@@ -20,7 +20,21 @@ export function getBridgePath(): string {
   if (app.isPackaged) {
     return join(process.resourcesPath, 'resources', 'native-messaging-host', 'vicu-bridge.js')
   }
-  return join(app.getAppPath(), 'resources', 'native-messaging-host', 'vicu-bridge.js')
+  // Dev mode: resources live at <project>/resources/, but app.getAppPath() can
+  // resolve to different places depending on how electron-vite runs us
+  // (sometimes the project root, sometimes out/main/ when launched directly).
+  // Probe candidate paths in order and pick the first that exists.
+  const appPath = app.getAppPath()
+  const candidates = [
+    join(appPath, 'resources', 'native-messaging-host', 'vicu-bridge.js'),
+    join(appPath, '..', '..', 'resources', 'native-messaging-host', 'vicu-bridge.js'),
+    join(appPath, '..', 'resources', 'native-messaging-host', 'vicu-bridge.js'),
+    join(process.cwd(), 'resources', 'native-messaging-host', 'vicu-bridge.js'),
+  ]
+  for (const p of candidates) {
+    if (existsSync(p)) return p
+  }
+  return candidates[0] // fallback, even if non-existent, so the error is visible
 }
 
 function getBatWrapperPath(): string {
@@ -65,6 +79,30 @@ function getMacManifestPath(browserDir: string, hostName: string = HOST_NAME): s
   return join(browserDir, `${hostName}.json`)
 }
 
+// --- Linux manifest paths ---
+// Linux stores native messaging host manifests per-browser under ~/.config (or
+// $XDG_CONFIG_HOME). We iterate all known browser config dirs; we only write
+// into dirs whose parent (the browser's config root) already exists, so we
+// don't fabricate config directories for browsers the user doesn't have.
+function getLinuxConfigRoot(): string {
+  return process.env.XDG_CONFIG_HOME || join(home, '.config')
+}
+
+function getLinuxChromeHostDirs(): Array<{ browserRoot: string; hostDir: string }> {
+  const xdg = getLinuxConfigRoot()
+  return [
+    { browserRoot: join(xdg, 'google-chrome'), hostDir: join(xdg, 'google-chrome', 'NativeMessagingHosts') },
+    { browserRoot: join(xdg, 'chromium'), hostDir: join(xdg, 'chromium', 'NativeMessagingHosts') },
+    { browserRoot: join(xdg, 'microsoft-edge'), hostDir: join(xdg, 'microsoft-edge', 'NativeMessagingHosts') },
+    { browserRoot: join(xdg, 'BraveSoftware', 'Brave-Browser'), hostDir: join(xdg, 'BraveSoftware', 'Brave-Browser', 'NativeMessagingHosts') },
+    { browserRoot: join(xdg, 'vivaldi'), hostDir: join(xdg, 'vivaldi', 'NativeMessagingHosts') },
+  ]
+}
+
+function getLinuxFirefoxHostDir(): string {
+  return join(home, '.mozilla', 'native-messaging-hosts')
+}
+
 // macOS GUI apps have PATH = /usr/bin:/bin:/usr/sbin:/sbin which won't find
 // node installed via Homebrew, nvm, fnm, etc. Resolve the full path at
 // registration time and embed it in a shell wrapper.
@@ -103,6 +141,26 @@ export function registerChromeHost(extensionId: string): void {
     const edgeDir = getMacEdgeHostDir()
     mkdirSync(edgeDir, { recursive: true })
     writeFileSync(getMacManifestPath(edgeDir), JSON.stringify(manifest, null, 2), 'utf-8')
+    return
+  }
+
+  if (isLinux) {
+    const hostPath = ensureShellWrapper()
+    const manifest = {
+      name: HOST_NAME,
+      description: 'Vicu Browser Link native messaging bridge',
+      path: hostPath,
+      type: 'stdio',
+      allowed_origins: extensionId ? [`chrome-extension://${extensionId}/`] : [],
+    }
+    for (const { browserRoot, hostDir } of getLinuxChromeHostDirs()) {
+      // Only write into browsers the user actually has configured.
+      if (!existsSync(browserRoot)) continue
+      try {
+        mkdirSync(hostDir, { recursive: true })
+        writeFileSync(join(hostDir, `${HOST_NAME}.json`), JSON.stringify(manifest, null, 2), 'utf-8')
+      } catch { /* ignore per-browser failures */ }
+    }
     return
   }
 
@@ -153,6 +211,39 @@ export function registerFirefoxHost(): void {
     return
   }
 
+  if (isLinux) {
+    const hostPath = ensureShellWrapper()
+    const firefoxDir = getLinuxFirefoxHostDir()
+    try {
+      mkdirSync(firefoxDir, { recursive: true })
+    } catch { /* ignore */ }
+
+    // Vicu's own future Firefox extension
+    const vicuManifest = {
+      name: HOST_NAME,
+      description: 'Vicu Browser Link native messaging bridge',
+      path: hostPath,
+      type: 'stdio',
+      allowed_extensions: ['browser-link@vicu.app'],
+    }
+    try {
+      writeFileSync(join(firefoxDir, `${HOST_NAME}.json`), JSON.stringify(vicuManifest, null, 2), 'utf-8')
+    } catch { /* ignore */ }
+
+    // vikunja-quick-entry's signed Firefox extension (already on AMO)
+    const vqeManifest = {
+      name: VQE_HOST_NAME,
+      description: 'Vicu Browser Link native messaging bridge (vikunja-quick-entry compat)',
+      path: hostPath,
+      type: 'stdio',
+      allowed_extensions: ['browser-link@vikunja-quick-entry.app'],
+    }
+    try {
+      writeFileSync(join(firefoxDir, `${VQE_HOST_NAME}.json`), JSON.stringify(vqeManifest, null, 2), 'utf-8')
+    } catch { /* ignore */ }
+    return
+  }
+
   if (!isWindows) return
   const hostPath = ensureBatWrapper()
 
@@ -200,6 +291,17 @@ export function unregisterHosts(): void {
     return
   }
 
+  if (isLinux) {
+    for (const { hostDir } of getLinuxChromeHostDirs()) {
+      try { unlinkSync(join(hostDir, `${HOST_NAME}.json`)) } catch { /* ignore */ }
+    }
+    const firefoxDir = getLinuxFirefoxHostDir()
+    try { unlinkSync(join(firefoxDir, `${HOST_NAME}.json`)) } catch { /* ignore */ }
+    try { unlinkSync(join(firefoxDir, `${VQE_HOST_NAME}.json`)) } catch { /* ignore */ }
+    try { unlinkSync(join(app.getPath('userData'), 'vicu-bridge.sh')) } catch { /* ignore */ }
+    return
+  }
+
   if (!isWindows) return
   const chromePath = getChromeHostManifestPath()
   try { unlinkSync(chromePath) } catch { /* ignore */ }
@@ -219,6 +321,16 @@ export function isRegistered(): { chrome: boolean; firefox: boolean } {
       firefox: existsSync(getMacManifestPath(firefoxDir, HOST_NAME))
         && existsSync(getMacManifestPath(firefoxDir, VQE_HOST_NAME)),
     }
+  }
+
+  if (isLinux) {
+    const chrome = getLinuxChromeHostDirs().some(({ hostDir }) =>
+      existsSync(join(hostDir, `${HOST_NAME}.json`))
+    )
+    const firefoxDir = getLinuxFirefoxHostDir()
+    const firefox = existsSync(join(firefoxDir, `${HOST_NAME}.json`))
+      && existsSync(join(firefoxDir, `${VQE_HOST_NAME}.json`))
+    return { chrome, firefox }
   }
 
   if (!isWindows) return { chrome: false, firefox: false }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -12,7 +12,7 @@ import { getBrowserContext, type BrowserContext } from './browser-client'
 import { getBrowserUrlFromWindow, prewarmUrlReader, shutdownUrlReader, BROWSER_PROCESSES } from './window-url-reader'
 import { isRegistered, unregisterHosts, registerHosts } from './browser-host-registration'
 import { checkForUpdates } from './update-checker'
-import { isMac, isWindows } from './platform'
+import { isMac, isWindows, isLinux } from './platform'
 import { setupApplicationMenu } from './app-menu'
 import { storeAPIToken, getAPIToken, isEncryptionAvailable, API_TOKEN_NO_EXPIRY } from './auth/token-store'
 
@@ -32,6 +32,7 @@ registerQuickEntryState({
   hideQuickView: () => hideQuickView(),
   setViewerHeight: (h) => setViewerHeight(h),
   applyQuickEntrySettings: () => applyQuickEntrySettings(),
+  getLastShortcutStatus: () => lastShortcutStatus,
 })
 
 // --- Quick Entry/View constants ---
@@ -99,8 +100,16 @@ async function showQuickEntry(): Promise<void> {
   const fgHwnd = getForegroundWindowHandle()
 
   const isObsidian = fgProcess === 'Obsidian' || fgProcess === 'obsidian'
-  const wantObsidian = !!(config?.obsidian_mode && config.obsidian_mode !== 'off' && config.obsidian_api_key && isObsidian)
-  const wantBrowser = !isObsidian && !!(config?.browser_link_mode && config.browser_link_mode !== 'off' && BROWSER_PROCESSES.has(fgProcess))
+  // Obsidian integration is disabled on Linux by design — Wayland restricts
+  // foreground-process detection and "always-fire" Obsidian fetches would
+  // surprise users who aren't exclusively working in Obsidian. Users on Linux
+  // can still open Obsidian deep links via plain text URIs in task notes.
+  const wantObsidian = !isLinux && !!(config?.obsidian_mode && config.obsidian_mode !== 'off' && config.obsidian_api_key && isObsidian)
+  // Browser link: on Linux we trust the extension cache's 3-second freshness
+  // window to gate stale data instead of foreground checks, so skip the
+  // BROWSER_PROCESSES gate (fgProcess is always '' on Wayland).
+  const processIsBrowser = isLinux ? true : BROWSER_PROCESSES.has(fgProcess)
+  const wantBrowser = !isObsidian && !!(config?.browser_link_mode && config.browser_link_mode !== 'off' && processIsBrowser)
 
   // 3. Browser context: try extension cache first (<1ms sync file read).
   let browserContext: BrowserContext | null = null
@@ -263,8 +272,28 @@ function setViewerHeight(height: number): void {
 }
 
 // --- Shortcut registration ---
-function registerQuickEntryShortcuts(config: AppConfig): { entry: boolean; viewer: boolean } {
-  const result = { entry: false, viewer: false }
+// Latest global-shortcut registration state. Surfaced to the renderer via the
+// `get-global-shortcut-status` IPC so Settings can show a warning banner when
+// registration fails (most common on Wayland, where Electron 33 can't talk to
+// the XDG portal).
+//
+// `waylandLimited` is a Linux-specific caveat: on Wayland, Electron's
+// globalShortcut.register() happily returns true, but the key only fires when
+// Vicu itself is focused because Wayland's security model doesn't forward keys
+// to unfocused clients. We detect the session type and surface it so Settings
+// can show a proactive warning even when registration "succeeded".
+const isWaylandSession = isLinux && (
+  process.env.XDG_SESSION_TYPE === 'wayland' || !!process.env.WAYLAND_DISPLAY
+)
+
+let lastShortcutStatus: { entry: boolean; viewer: boolean; waylandLimited: boolean } = {
+  entry: false,
+  viewer: false,
+  waylandLimited: isWaylandSession,
+}
+
+function registerQuickEntryShortcuts(config: AppConfig): { entry: boolean; viewer: boolean; waylandLimited: boolean } {
+  const result = { entry: false, viewer: false, waylandLimited: isWaylandSession }
 
   if (config.quick_entry_enabled) {
     const entryHotkey = config.quick_entry_hotkey || DEFAULT_QUICK_ENTRY_HOTKEY
@@ -286,6 +315,7 @@ function registerQuickEntryShortcuts(config: AppConfig): { entry: boolean; viewe
     }
   }
 
+  lastShortcutStatus = result
   return result
 }
 
@@ -371,9 +401,13 @@ function initQuickEntryWindows(config: AppConfig): void {
 }
 
 // Apply quick entry settings (called from IPC when settings change)
-function applyQuickEntrySettings(): { entry: boolean; viewer: boolean } {
+function applyQuickEntrySettings(): { entry: boolean; viewer: boolean; waylandLimited: boolean } {
   const config = loadConfig()
-  if (!config) return { entry: false, viewer: false }
+  if (!config) {
+    const empty = { entry: false, viewer: false, waylandLimited: isWaylandSession }
+    lastShortcutStatus = empty
+    return empty
+  }
 
   // Unregister existing shortcuts
   globalShortcut.unregisterAll()
@@ -421,7 +455,9 @@ function applyQuickEntrySettings(): { entry: boolean; viewer: boolean } {
     openAtLogin: config.launch_on_startup === true,
     ...(isMac ? { openAsHidden: true, name: 'Vicu' } : {}),
   })
-  return { entry: false, viewer: false }
+  const empty = { entry: false, viewer: false, waylandLimited: isWaylandSession }
+  lastShortcutStatus = empty
+  return empty
 }
 
 // Augment the app type
@@ -431,12 +467,56 @@ declare module 'electron' {
   }
 }
 
+// Pin the app name so `app.getPath('userData')` resolves to ~/.config/vicu on
+// Linux whether we're running the packaged AppImage (which has a package.json
+// inside the asar with name: "vicu") or a bare `electron ./out/main/index.js`
+// dev run (which otherwise falls back to Electron's default "Electron" name
+// and diverges from the bundled vicu-bridge.js that hardcodes "vicu").
+app.setName('vicu')
+
+// Linux: force Chromium's "basic" password-store backend. The default is
+// "detect", which tries libsecret (gnome-keyring / KWallet) and falls back
+// to the basic backend if nothing is found. The detection path, however,
+// deadlocks when the secrets service is running but the "login" keyring
+// collection doesn't exist — common on fresh user accounts and minimal
+// desktop installs — and in that state `safeStorage.isEncryptionAvailable()`
+// returns false so `encryptString()` throws. Pinning to "basic" avoids the
+// deadlock and gives safeStorage a working (if obfuscated-not-encrypted)
+// backend on any Linux system without requiring an unlocked keyring.
+// Must be set before `app.whenReady()`.
+if (isLinux) {
+  app.commandLine.appendSwitch('password-store', 'basic')
+}
+
+// CLI argument parsing. Primarily used on Wayland as an escape hatch for
+// Vicu's global hotkeys: users bind their DE's keyboard shortcut to
+// `vicu --quick-entry` / `vicu --quick-view`, and the already-running instance
+// opens the respective window via the second-instance handler below.
+function parseIntent(argv: readonly string[]): 'quick-entry' | 'quick-view' | null {
+  if (argv.includes('--quick-entry')) return 'quick-entry'
+  if (argv.includes('--quick-view')) return 'quick-view'
+  return null
+}
+let startupIntent: 'quick-entry' | 'quick-view' | null = parseIntent(process.argv)
+
 // Single instance lock — quit if another instance is already running
 const gotLock = app.requestSingleInstanceLock()
 if (!gotLock) {
   app.quit()
 } else {
-  app.on('second-instance', () => {
+  app.on('second-instance', (_event, argv) => {
+    // If the second instance was launched with --quick-entry/--quick-view
+    // (typically from a DE keyboard-shortcut binding on Wayland), show that
+    // window and do NOT raise the main window.
+    const intent = parseIntent(argv)
+    if (intent === 'quick-entry') {
+      showQuickEntry()
+      return
+    }
+    if (intent === 'quick-view') {
+      showQuickView()
+      return
+    }
     if (mainWindow) {
       mainWindow.show()
       if (mainWindow.isMinimized()) mainWindow.restore()
@@ -578,8 +658,12 @@ if (!gotLock) {
       })
     }
 
-    // Quick Entry/View: if either enabled, set up tray + windows + hotkeys
-    if (config?.quick_entry_enabled || config?.quick_view_enabled !== false) {
+    // Quick Entry/View: if either enabled, set up tray + windows + hotkeys.
+    // Require config to be non-null: on first launch loadConfig() returns null,
+    // and `config?.quick_view_enabled !== false` is vacuously true (undefined
+    // !== false), which previously caused initQuickEntryWindows(null) to throw
+    // an unhandled rejection before the user finished setup.
+    if (config && (config.quick_entry_enabled || config.quick_view_enabled !== false)) {
       setupTray()
       initQuickEntryWindows(config)
       globalShortcut.unregisterAll() // Clear stale registrations from crashes
@@ -600,6 +684,18 @@ if (!gotLock) {
         })
       }
     }
+
+    // If the app was launched with --quick-entry/--quick-view (e.g. a DE
+    // keyboard shortcut on Wayland starting a cold instance), open the
+    // requested window and hide the main window so it feels like a hotkey.
+    if (startupIntent === 'quick-entry' && quickEntryWindow) {
+      mainWindow.hide()
+      showQuickEntry()
+    } else if (startupIntent === 'quick-view' && quickViewWindow) {
+      mainWindow.hide()
+      showQuickView()
+    }
+    startupIntent = null
   })
 
   app.on('window-all-closed', () => {

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -41,6 +41,7 @@ import {
   getQuickEntryWindow,
   getQuickViewWindow,
   applyQuickEntrySettings,
+  getLastShortcutStatus,
 } from './quick-entry-state'
 import { getAPIToken, storeAPIToken, isEncryptionAvailable, API_TOKEN_NO_EXPIRY } from './auth/token-store'
 import { sendTestNotification, rescheduleNotifications, refreshTaskReminders } from './notifications'
@@ -541,6 +542,49 @@ export function registerIpcHandlers(): void {
   // --- Apply Quick Entry Settings (called from renderer settings page) ---
   ipcMain.handle('apply-quick-entry-settings', () => {
     return applyQuickEntrySettings()
+  })
+
+  // --- Global shortcut registration status ---
+  // Returns the latest success/failure state of the Quick Entry / Quick View
+  // globalShortcut.register() calls. The Settings view uses this to surface a
+  // warning banner on platforms where registration can silently fail (notably
+  // Wayland).
+  ipcMain.handle('get-global-shortcut-status', () => {
+    return getLastShortcutStatus()
+  })
+
+  // --- Hotkey launcher command (Linux/Wayland escape hatch) ---
+  // Returns the exact shell command a user should bind in their desktop
+  // environment's keyboard settings to trigger Quick Entry / Quick View on
+  // Wayland. All paths returned are absolute so the command works regardless
+  // of the spawning process's working directory (GNOME/KDE custom-shortcut
+  // spawners run with cwd = $HOME or /, not the project root).
+  ipcMain.handle('get-hotkey-launcher-command', () => {
+    const quote = (s: string) => (/[\s"']/.test(s) ? `"${s.replace(/"/g, '\\"')}"` : s)
+
+    let base: string
+    let kind: 'appimage' | 'packaged' | 'dev'
+    const appImage = process.env.APPIMAGE
+    if (appImage && appImage.length > 0) {
+      // AppImage: a single self-contained executable, no app path arg needed.
+      base = quote(appImage)
+      kind = 'appimage'
+    } else if (app.isPackaged) {
+      // Other packaged Linux formats (snap, .deb, tarball, etc.).
+      base = quote(process.execPath)
+      kind = 'packaged'
+    } else {
+      // Dev mode: electron binary + absolute app path.
+      const appPath = process.argv[1] ? path.resolve(process.argv[1]) : ''
+      base = appPath ? `${quote(process.execPath)} ${quote(appPath)}` : quote(process.execPath)
+      kind = 'dev'
+    }
+
+    return {
+      quickEntry: `${base} --quick-entry`,
+      quickView: `${base} --quick-view`,
+      kind,
+    }
   })
 
   // --- Standalone mode IPC ---

--- a/src/main/quick-entry-state.ts
+++ b/src/main/quick-entry-state.ts
@@ -4,11 +4,12 @@ import type { BrowserWindow } from 'electron'
 // This avoids a circular dependency between the two modules.
 
 type WindowGetter = () => BrowserWindow | null
-export type HotkeyRegistrationResult = { entry: boolean; viewer: boolean }
+export type HotkeyRegistrationResult = { entry: boolean; viewer: boolean; waylandLimited: boolean }
 
 type VoidFn = () => void
 type HeightFn = (h: number) => void
 type ApplySettingsFn = () => HotkeyRegistrationResult
+type StatusFn = () => HotkeyRegistrationResult
 
 let _getMainWindow: WindowGetter = () => null
 let _getQuickEntryWindow: WindowGetter = () => null
@@ -16,7 +17,8 @@ let _getQuickViewWindow: WindowGetter = () => null
 let _hideQuickEntry: VoidFn = () => {}
 let _hideQuickView: VoidFn = () => {}
 let _setViewerHeight: HeightFn = () => {}
-let _applyQuickEntrySettings: ApplySettingsFn = () => ({ entry: false, viewer: false })
+let _applyQuickEntrySettings: ApplySettingsFn = () => ({ entry: false, viewer: false, waylandLimited: false })
+let _getLastShortcutStatus: StatusFn = () => ({ entry: false, viewer: false, waylandLimited: false })
 
 export function registerQuickEntryState(fns: {
   getMainWindow: WindowGetter
@@ -26,6 +28,7 @@ export function registerQuickEntryState(fns: {
   hideQuickView: VoidFn
   setViewerHeight: HeightFn
   applyQuickEntrySettings: ApplySettingsFn
+  getLastShortcutStatus: StatusFn
 }): void {
   _getMainWindow = fns.getMainWindow
   _getQuickEntryWindow = fns.getQuickEntryWindow
@@ -34,6 +37,7 @@ export function registerQuickEntryState(fns: {
   _hideQuickView = fns.hideQuickView
   _setViewerHeight = fns.setViewerHeight
   _applyQuickEntrySettings = fns.applyQuickEntrySettings
+  _getLastShortcutStatus = fns.getLastShortcutStatus
 }
 
 export function getMainWindow(): BrowserWindow | null { return _getMainWindow() }
@@ -43,3 +47,4 @@ export function hideQuickEntry(): void { _hideQuickEntry() }
 export function hideQuickView(): void { _hideQuickView() }
 export function setViewerHeight(h: number): void { _setViewerHeight(h) }
 export function applyQuickEntrySettings(): HotkeyRegistrationResult { return _applyQuickEntrySettings() }
+export function getLastShortcutStatus(): HotkeyRegistrationResult { return _getLastShortcutStatus() }

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -1,7 +1,7 @@
-import { BrowserWindow, session } from 'electron'
+import { BrowserWindow, screen, session } from 'electron'
 import { join } from 'path'
 import type { AppConfig } from './config'
-import { isMac } from './platform'
+import { isMac, isLinux } from './platform'
 
 const SHADOW_PADDING = 20
 const DRAG_HANDLE_HEIGHT = 14
@@ -9,11 +9,24 @@ const DRAG_HANDLE_HEIGHT = 14
 export function createMainWindow(config: AppConfig | null): BrowserWindow {
   const bounds = config?.window_bounds
 
+  // First-launch safety: compute an explicit centered position from the primary
+  // display's work area when no bounds are saved. Wayland compositors cannot
+  // let clients self-position; passing undefined x/y for a frameless window can
+  // trigger a maximize on mutter, which is why Linux first-launches looked
+  // fullscreen before this fix.
+  const defaultWidth = bounds?.width ?? 1100
+  const defaultHeight = bounds?.height ?? 720
+  const workArea = screen.getPrimaryDisplay().workArea
+  const centeredX = workArea.x + Math.max(0, Math.round((workArea.width - defaultWidth) / 2))
+  const centeredY = workArea.y + Math.max(0, Math.round((workArea.height - defaultHeight) / 2))
+  const fallbackX = bounds?.x ?? centeredX
+  const fallbackY = bounds?.y ?? centeredY
+
   const win = new BrowserWindow({
-    width: bounds?.width ?? 1100,
-    height: bounds?.height ?? 720,
-    x: bounds?.x,
-    y: bounds?.y,
+    width: defaultWidth,
+    height: defaultHeight,
+    x: fallbackX,
+    y: fallbackY,
     minWidth: 800,
     minHeight: 500,
     ...(isMac
@@ -52,9 +65,21 @@ export function createMainWindow(config: AppConfig | null): BrowserWindow {
     })
   }
 
-  // Show window once ready to avoid flash
+  // Show window once ready to avoid flash.
+  // On Linux (Wayland/mutter in particular) frameless xdg_toplevels without
+  // server-side decorations get auto-maximized by the compositor when first
+  // mapped. Explicitly unmaximize and force the bounds we asked for.
   win.once('ready-to-show', () => {
     win.show()
+    if (isLinux) {
+      if (win.isMaximized()) win.unmaximize()
+      win.setBounds({
+        x: fallbackX,
+        y: fallbackY,
+        width: defaultWidth,
+        height: defaultHeight,
+      })
+    }
   })
 
   // Load renderer

--- a/src/main/window-url-reader.ts
+++ b/src/main/window-url-reader.ts
@@ -92,6 +92,12 @@ export function getBrowserUrlFromWindow(processName: string, hwnd?: number): Pro
     return getBrowserUrlMacOS(processName)
   }
 
+  // Linux/Wayland: no cross-browser way to read the active tab URL. The bundled
+  // browser extension (native-messaging host) is the only supported path.
+  if (process.platform === 'linux') {
+    return Promise.resolve(null)
+  }
+
   // Windows: PowerShell implementation
   return new Promise((resolve) => {
     try {

--- a/src/main/window-url-reader.ts
+++ b/src/main/window-url-reader.ts
@@ -2,9 +2,10 @@ import { app } from 'electron'
 import { spawn, execFile, type ChildProcess } from 'child_process'
 import { join } from 'path'
 import type { BrowserContext } from './browser-client'
+import { isMac, isWindows, isLinux } from './platform'
 
 export const BROWSER_PROCESSES = new Set(
-  process.platform === 'darwin'
+  isMac
     ? ['Google Chrome', 'Firefox', 'Microsoft Edge', 'Brave Browser', 'Safari', 'Opera', 'Vivaldi', 'Arc']
     : ['chrome', 'firefox', 'msedge', 'brave', 'opera', 'vivaldi']
 )
@@ -88,13 +89,13 @@ function getBrowserUrlMacOS(appName: string): Promise<BrowserContext | null> {
 // --- Main entry point: platform-aware URL detection ---
 
 export function getBrowserUrlFromWindow(processName: string, hwnd?: number): Promise<BrowserContext | null> {
-  if (process.platform === 'darwin') {
+  if (isMac) {
     return getBrowserUrlMacOS(processName)
   }
 
   // Linux/Wayland: no cross-browser way to read the active tab URL. The bundled
   // browser extension (native-messaging host) is the only supported path.
-  if (process.platform === 'linux') {
+  if (isLinux) {
     return Promise.resolve(null)
   }
 
@@ -139,7 +140,7 @@ export function getBrowserUrlFromWindow(processName: string, hwnd?: number): Pro
 }
 
 export function prewarmUrlReader(): void {
-  if (process.platform !== 'win32') return
+  if (!isWindows) return
   try {
     prewarmProcess = spawn('powershell.exe', [
       '-NoProfile',
@@ -156,7 +157,7 @@ export function prewarmUrlReader(): void {
 }
 
 export function shutdownUrlReader(): void {
-  if (process.platform !== 'win32') return
+  if (!isWindows) return
   if (prewarmProcess && !prewarmProcess.killed) {
     try { prewarmProcess.kill() } catch { /* ignore */ }
     prewarmProcess = null

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -54,7 +54,9 @@ export interface ElectronAPI {
   testNotification(): Promise<void>
   rescheduleNotifications(): Promise<void>
   refreshTaskReminders(): Promise<void>
-  applyQuickEntrySettings(): Promise<void>
+  applyQuickEntrySettings(): Promise<{ entry: boolean; viewer: boolean; waylandLimited: boolean }>
+  getGlobalShortcutStatus(): Promise<{ entry: boolean; viewer: boolean; waylandLimited: boolean }>
+  getHotkeyLauncherCommand(): Promise<{ quickEntry: string; quickView: string; kind: 'appimage' | 'packaged' | 'dev' }>
 
   // Obsidian
   openDeepLink(url: string): Promise<void>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -109,7 +109,11 @@ const api = {
 
   // Quick Entry settings
   applyQuickEntrySettings: () =>
-    ipcRenderer.invoke('apply-quick-entry-settings') as Promise<{ entry: boolean; viewer: boolean }>,
+    ipcRenderer.invoke('apply-quick-entry-settings') as Promise<{ entry: boolean; viewer: boolean; waylandLimited: boolean }>,
+  getGlobalShortcutStatus: () =>
+    ipcRenderer.invoke('get-global-shortcut-status') as Promise<{ entry: boolean; viewer: boolean; waylandLimited: boolean }>,
+  getHotkeyLauncherCommand: () =>
+    ipcRenderer.invoke('get-hotkey-launcher-command') as Promise<{ quickEntry: string; quickView: string; kind: 'appimage' | 'packaged' | 'dev' }>,
 
   // Update checker
   checkForUpdate: () => ipcRenderer.invoke('update:check'),

--- a/src/renderer/components/settings/BrowserSettings.tsx
+++ b/src/renderer/components/settings/BrowserSettings.tsx
@@ -14,12 +14,6 @@ export function BrowserSettings({ config, onChange, disabled }: BrowserSettingsP
   const [registering, setRegistering] = useState(false)
   const mode = config.browser_link_mode ?? 'ask'
 
-  useEffect(() => {
-    if (expanded && mode !== 'off') {
-      window.api.checkBrowserHostRegistration().then(setRegStatus)
-    }
-  }, [expanded, mode])
-
   const handleRegister = useCallback(async () => {
     setRegistering(true)
     try {
@@ -28,6 +22,22 @@ export function BrowserSettings({ config, onChange, disabled }: BrowserSettingsP
     } catch { /* ignore */ }
     setRegistering(false)
   }, [])
+
+  useEffect(() => {
+    if (!expanded || mode === 'off') return
+    let cancelled = false
+    window.api.checkBrowserHostRegistration().then((status) => {
+      if (cancelled) return
+      setRegStatus(status)
+      // If the user toggled browser link on but nothing is registered yet,
+      // write the manifests automatically so Firefox-only users don't have
+      // to hunt for a button.
+      if (!status.chrome && !status.firefox) {
+        handleRegister()
+      }
+    })
+    return () => { cancelled = true }
+  }, [expanded, mode, handleRegister])
 
   return (
     <div className={`rounded-lg border border-[var(--border-color)] bg-[var(--bg-primary)] p-5${disabled ? ' opacity-50 pointer-events-none' : ''}`}>
@@ -85,16 +95,14 @@ export function BrowserSettings({ config, onChange, disabled }: BrowserSettingsP
                 </div>
               )}
 
-              {config.browser_extension_id && (
-                <button
-                  type="button"
-                  onClick={handleRegister}
-                  disabled={registering}
-                  className="rounded-md border border-[var(--border-color)] px-4 py-2 text-sm text-[var(--text-primary)] hover:bg-[var(--bg-hover)] disabled:opacity-50"
-                >
-                  {registering ? 'Registering...' : 'Re-register Bridge'}
-                </button>
-              )}
+              <button
+                type="button"
+                onClick={handleRegister}
+                disabled={registering}
+                className="rounded-md border border-[var(--border-color)] px-4 py-2 text-sm text-[var(--text-primary)] hover:bg-[var(--bg-hover)] disabled:opacity-50"
+              >
+                {registering ? 'Registering...' : 'Re-register Bridge'}
+              </button>
 
               <div>
                 <button

--- a/src/renderer/components/settings/QuickEntrySettings.tsx
+++ b/src/renderer/components/settings/QuickEntrySettings.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react'
+import { api } from '@/lib/api'
 import { cn } from '@/lib/cn'
 import { HotkeyRecorder } from './HotkeyRecorder'
 import type { AppConfig, Project, SecondaryProject, ViewerFilter } from '@/lib/vikunja-types'
@@ -6,11 +8,36 @@ interface QuickEntrySettingsProps {
   config: AppConfig
   projects: Project[]
   onChange: (partial: Partial<AppConfig>) => void
-  hotkeyWarnings?: { entry: boolean; viewer: boolean }
+  hotkeyWarnings?: { entry: boolean; viewer: boolean; waylandLimited: boolean }
 }
 
 
+const HOTKEY_FAILURE_COPY = window.api.platform === 'linux'
+  ? 'Failed to register. On Wayland this usually means the compositor blocked the shortcut — see the Wayland notice above for a workaround.'
+  : 'Failed to register — hotkey may be in use by another application'
+
 export function QuickEntrySettings({ config, projects, onChange, hotkeyWarnings }: QuickEntrySettingsProps) {
+  const [launcherCmd, setLauncherCmd] = useState<{ quickEntry: string; quickView: string; kind: 'appimage' | 'packaged' | 'dev' } | null>(null)
+  const [copied, setCopied] = useState<'entry' | 'view' | null>(null)
+
+  // Fetch the launcher command once on mount on Linux. Done unconditionally
+  // (not gated on hotkeyWarnings) so it's always ready by the time the
+  // Wayland warning renders, and so a slow or missed warning state doesn't
+  // leave the banner showing instructions with no copyable command.
+  useEffect(() => {
+    if (window.api.platform !== 'linux') return
+    api.getHotkeyLauncherCommand().then(setLauncherCmd).catch((err) => {
+      console.error('[Settings] getHotkeyLauncherCommand failed:', err)
+    })
+  }, [])
+
+  const copy = (text: string, which: 'entry' | 'view') => {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(which)
+      setTimeout(() => setCopied(null), 1500)
+    })
+  }
+
   const entryEnabled = config.quick_entry_enabled ?? false
   const viewEnabled = config.quick_view_enabled === true
   const viewerFilter = config.viewer_filter ?? {
@@ -47,6 +74,68 @@ export function QuickEntrySettings({ config, projects, onChange, hotkeyWarnings 
       <h2 className="text-sm font-semibold text-[var(--text-primary)]">Quick Entry & Quick View</h2>
 
       <div className="mt-4 space-y-4">
+        {hotkeyWarnings?.waylandLimited && (entryEnabled || viewEnabled) && (
+          <div className="rounded-md border border-accent-orange/40 bg-accent-orange/10 px-3 py-3 text-xs text-[var(--text-primary)]">
+            <p className="mb-2 font-semibold text-accent-orange">
+              Wayland: Vicu hotkeys only fire when Vicu is focused
+            </p>
+            <p className="mb-2 text-[var(--text-secondary)]">
+              Wayland doesn't let applications grab global keyboard shortcuts. To get true global capture, bind a shortcut in your desktop environment's keyboard settings that runs Vicu with a command-line flag:
+            </p>
+            <ol className="mb-3 list-decimal space-y-1 pl-5 text-[var(--text-secondary)]">
+              <li>Open <strong className="text-[var(--text-primary)]">Settings → Keyboard → Custom Shortcuts</strong> (GNOME) or <strong className="text-[var(--text-primary)]">System Settings → Shortcuts → Custom Shortcuts</strong> (KDE).</li>
+              <li>Add a new shortcut. Paste the command below as the <em>Command</em>.</li>
+              <li>Set the key combo (e.g. <code className="rounded bg-[var(--bg-tertiary)] px-1">Alt+Shift+V</code>).</li>
+              <li>Keep Vicu running in the tray — the shortcut wakes the running instance.</li>
+            </ol>
+            {!launcherCmd && (
+              <div className="text-[var(--text-secondary)]">Loading command…</div>
+            )}
+            {launcherCmd?.kind === 'dev' && (
+              <div className="mb-2 rounded border border-yellow-500/40 bg-yellow-500/10 px-2 py-1.5 text-[11px] text-yellow-600 dark:text-yellow-400">
+                <strong>Dev build notice:</strong> the command below points at the unpackaged source tree and won't work outside this dev session. Use this feature from the installed AppImage for real keybinds.
+              </div>
+            )}
+            {launcherCmd && (
+              <div className="space-y-2">
+                {entryEnabled && (
+                  <div>
+                    <div className="mb-1 text-[var(--text-secondary)]">Quick Entry command:</div>
+                    <div className="flex items-center gap-2">
+                      <code className="flex-1 overflow-x-auto whitespace-nowrap rounded border border-[var(--border-color)] bg-[var(--bg-tertiary)] px-2 py-1 font-mono text-[11px] text-[var(--text-primary)]">
+                        {launcherCmd.quickEntry}
+                      </code>
+                      <button
+                        type="button"
+                        onClick={() => copy(launcherCmd.quickEntry, 'entry')}
+                        className="shrink-0 rounded border border-[var(--border-color)] bg-[var(--bg-secondary)] px-2 py-1 text-[11px] font-medium text-[var(--text-primary)] hover:bg-[var(--bg-tertiary)]"
+                      >
+                        {copied === 'entry' ? 'Copied' : 'Copy'}
+                      </button>
+                    </div>
+                  </div>
+                )}
+                {viewEnabled && (
+                  <div>
+                    <div className="mb-1 text-[var(--text-secondary)]">Quick View command:</div>
+                    <div className="flex items-center gap-2">
+                      <code className="flex-1 overflow-x-auto whitespace-nowrap rounded border border-[var(--border-color)] bg-[var(--bg-tertiary)] px-2 py-1 font-mono text-[11px] text-[var(--text-primary)]">
+                        {launcherCmd.quickView}
+                      </code>
+                      <button
+                        type="button"
+                        onClick={() => copy(launcherCmd.quickView, 'view')}
+                        className="shrink-0 rounded border border-[var(--border-color)] bg-[var(--bg-secondary)] px-2 py-1 text-[11px] font-medium text-[var(--text-primary)] hover:bg-[var(--bg-tertiary)]"
+                      >
+                        {copied === 'view' ? 'Copied' : 'Copy'}
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )}
         {/* Enable toggles */}
         <div className="space-y-2">
           <label className="flex cursor-pointer items-center gap-2">
@@ -91,7 +180,7 @@ export function QuickEntrySettings({ config, projects, onChange, hotkeyWarnings 
                   />
                   {hotkeyWarnings?.entry === false && (
                     <p className="mt-1 text-xs text-accent-orange">
-                      Failed to register — hotkey may be in use by another application
+                      {HOTKEY_FAILURE_COPY}
                     </p>
                   )}
                 </div>
@@ -202,7 +291,7 @@ export function QuickEntrySettings({ config, projects, onChange, hotkeyWarnings 
                   />
                   {hotkeyWarnings?.viewer === false && (
                     <p className="mt-1 text-xs text-accent-orange">
-                      Failed to register — hotkey may be in use by another application
+                      {HOTKEY_FAILURE_COPY}
                     </p>
                   )}
                 </div>

--- a/src/renderer/lib/api.ts
+++ b/src/renderer/lib/api.ts
@@ -146,7 +146,13 @@ export const api = {
     window.api.refreshTaskReminders() as Promise<void>,
 
   applyQuickEntrySettings: () =>
-    window.api.applyQuickEntrySettings() as Promise<{ entry: boolean; viewer: boolean }>,
+    window.api.applyQuickEntrySettings() as Promise<{ entry: boolean; viewer: boolean; waylandLimited: boolean }>,
+
+  getGlobalShortcutStatus: () =>
+    window.api.getGlobalShortcutStatus() as Promise<{ entry: boolean; viewer: boolean; waylandLimited: boolean }>,
+
+  getHotkeyLauncherCommand: () =>
+    window.api.getHotkeyLauncherCommand() as Promise<{ quickEntry: string; quickView: string; kind: 'appimage' | 'packaged' | 'dev' }>,
 
   // Attachments
   fetchTaskAttachments: (taskId: number) =>

--- a/src/renderer/views/SettingsView.tsx
+++ b/src/renderer/views/SettingsView.tsx
@@ -28,7 +28,7 @@ export function SettingsView() {
   const [testStatus, setTestStatus] = useState<'idle' | 'testing' | 'success' | 'error'>('idle')
   const [testError, setTestError] = useState('')
   const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved'>('idle')
-  const [hotkeyWarnings, setHotkeyWarnings] = useState<{ entry: boolean; viewer: boolean } | undefined>(undefined)
+  const [hotkeyWarnings, setHotkeyWarnings] = useState<{ entry: boolean; viewer: boolean; waylandLimited: boolean } | undefined>(undefined)
 
   // Keep full config for preserving fields during save
   const [fullConfig, setFullConfig] = useState<AppConfig | null>(null)
@@ -54,6 +54,9 @@ export function SettingsView() {
         }
       }
     })
+    // Pull current global-shortcut registration state so the banner shows on
+    // cold start, not only after the user edits a hotkey.
+    api.getGlobalShortcutStatus().then(setHotkeyWarnings).catch(() => {})
   }, [])
 
   useEffect(() => {
@@ -468,7 +471,10 @@ export function SettingsView() {
           />
         )}
 
-        {fullConfig && (
+        {/* Obsidian integration is unavailable on Linux (Wayland blocks the
+            foreground-process detection it relies on) — hide the section
+            entirely so users aren't offered a dead setting. */}
+        {fullConfig && window.api.platform !== 'linux' && (
           <ObsidianSettings
             config={fullConfig}
             onChange={handleQuickEntryChange}

--- a/src/renderer/views/SetupView.tsx
+++ b/src/renderer/views/SetupView.tsx
@@ -261,7 +261,13 @@ export function SetupView({ onComplete }: SetupViewProps) {
   }
 
   return (
-    <div className="flex h-screen w-screen items-center justify-center bg-[var(--bg-primary)]">
+    <div className="relative flex h-screen w-screen items-center justify-center bg-[var(--bg-primary)]">
+      {/* Window drag strip — frameless windows need an explicit drag region,
+          especially on Wayland where the compositor can't auto-detect one. */}
+      <div
+        className="absolute inset-x-0 top-0 z-50 h-8"
+        style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
+      />
       <div className="w-full max-w-md rounded-xl border border-[var(--border-color)] bg-[var(--bg-secondary)] p-8 shadow-lg">
         <h1 className="mb-1 text-xl font-bold text-[var(--text-primary)]">
           Connect to Vikunja


### PR DESCRIPTION
## Summary

- Ships Vicu as a self-contained AppImage on Linux (x64 + arm64), wiring up the cross-platform plumbing that previously only worked on Windows and macOS.
- Includes a full CI pipeline: new `build-linux.yml` for PR smoke tests (+ a matching job in `release.yml` so tag pushes publish both arches).
- Intentionally disables Obsidian integration on Linux — it depends on OS-level foreground-process detection that Wayland restricts by design.

## What changed

**Build & packaging**
- `electron-builder.yml` — new `linux:` target: AppImage x64 + arm64, 512×512 icon, `StartupWMClass=Vicu` for GNOME dock grouping
- `package.json` — `dist:linux` / `dist:linux:publish` scripts
- `.github/workflows/release.yml` — `build-linux` matrix (`ubuntu-latest` x64, `ubuntu-24.04-arm` arm64)
- `.github/workflows/build-linux.yml` — new smoke-test workflow on PR/push/manual, `--publish never`

**Runtime fixes needed for Linux to work at all**
- `window-manager.ts` — compute centered bounds on first launch and `unmaximize()` in `ready-to-show`; mutter auto-maximizes frameless `xdg_toplevel`s without decorations
- `SetupView.tsx` — add a draggable top strip (previously only `AppShell` had `-webkit-app-region: drag`, leaving Setup windows immovable on Wayland)
- `token-store.ts` — plaintext fallback with `plain:` prefix when safeStorage is unavailable, plus pin `--password-store=basic` on Linux to avoid the libsecret deadlock on fresh user accounts
- `app.setName('vicu')` — so dev runs and packaged builds share `~/.config/vicu` as userData (was diverging to `~/.config/Electron` in dev, breaking the bundled native-messaging host)
- `window-url-reader.ts` — short-circuit on Linux instead of spawning `powershell.exe` (Wayland can't read tab URLs from window titles)

**Browser link mode (extension path)**
- `browser-host-registration.ts` — Linux branches writing manifests to `~/.config/{google-chrome,chromium,microsoft-edge,BraveSoftware/Brave-Browser,vivaldi}/NativeMessagingHosts/` and `~/.mozilla/native-messaging-hosts/`, skipping browsers the user doesn't have installed
- `getBridgePath()` — probes candidate paths in dev mode instead of hardcoding one `app.getAppPath()`-relative location
- `BrowserSettings.tsx` — auto-register hosts when the user toggles mode away from `off`; expose the re-register button to Firefox-only users (previously gated on a Chrome extension ID)
- `index.ts` — skip the `BROWSER_PROCESSES` foreground gate on Linux so the extension cache is actually read (`fgProcess` is always `''` on Wayland)

**Wayland global-hotkey escape hatch**
- `--quick-entry` / `--quick-view` CLI flags parsed in the `second-instance` handler so users can bind a DE keyboard shortcut to `"/path/to/Vicu.AppImage --quick-entry"` for real global capture that Electron's `globalShortcut` can't provide on Wayland
- `get-hotkey-launcher-command` IPC returns a copy-pasteable command (prefers `$APPIMAGE` / `process.execPath`, marks dev paths as such)
- `QuickEntrySettings.tsx` — proactive Wayland banner with numbered DE-keybind setup steps and copy buttons

**Obsidian integration**
- Hidden on Linux in `SettingsView`, forced `wantObsidian=false` in `index.ts`

## Test plan

- [ ] `Build Linux` workflow succeeds on both x64 and arm64 runners
- [ ] `Build macOS` workflow still passes (verify no regression)
- [ ] Download the x64 AppImage artifact and launch on a Linux Wayland session:
  - [ ] App opens at ~1100×720 centered, not maximized
  - [ ] Setup screen is draggable from the top strip
  - [ ] Completing setup lands on the inbox view
  - [ ] System tray icon appears (requires AppIndicator extension on GNOME)
- [ ] Enable Browser Link mode in Settings → verify `~/.config/vicu/vicu-bridge.sh` + Firefox manifests in `~/.mozilla/native-messaging-hosts/`
- [ ] Install the bundled Firefox extension, press Quick Entry hotkey while focused on a tab → URL + title prefilled
- [ ] Verify Settings → Quick Entry / View shows the Wayland banner with a copy-pasteable `--quick-entry` command
- [ ] Verify Obsidian section is hidden in Settings on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)